### PR TITLE
Item tower base

### DIFF
--- a/src/ccrec/models/bbpr.py
+++ b/src/ccrec/models/bbpr.py
@@ -11,6 +11,9 @@ import functools, torch, numpy as np, pandas as pd
 import os, itertools, dataclasses, warnings, collections, re, tqdm
 from ccrec.util import _device_mode_context
 from ccrec.util.shap_explainer import I2IExplainer
+from ccrec.models.item_tower import NaiveItemTower
+import rime
+from ccrec.env import create_zero_shot, parse_response
 
 # https://pytorch-lightning.readthedocs.io/en/stable/notebooks/lightning_examples/text-transformers.html
 
@@ -32,30 +35,6 @@ def _create_bert(model_name, freeze_bert):
     return model
 
 
-class _Tower(torch.nn.Module):
-    """ inputs -> model -> cls -> layer_norm -> final """
-    def __init__(self, model, layer_norm):
-        super().__init__()
-        self.model = model
-        self.layer_norm = layer_norm
-
-    @property
-    def device(self):
-        return self.model.device
-
-    def forward(self, cls=None, input_step='inputs', output_step='final', **inputs):
-        if input_step == 'inputs':
-            inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
-            cls = self.model(**inputs).last_hidden_state[:, 0]
-        else:  # cls
-            cls = cls.to(self.model.device)
-
-        if output_step == 'final':
-            return self.layer_norm(cls)
-        else:  # cls
-            return cls
-
-
 class _BertBPR(_LitValidated):
     def __init__(self, all_inputs, model_name='bert-base-uncased', freeze_bert=0,
                  n_negatives=10, valid_n_negatives=None, lr=None, weight_decay=None,
@@ -64,6 +43,7 @@ class _BertBPR(_LitValidated):
                  sample_with_prior=True, sample_with_posterior=0.5,
                  elementwise_affine=True,  # set to False to eliminate gradients from f(x)'f(x) in N/A class
                  pretrained_checkpoint=None,
+                 tokenizer=None, tokenizer_kw={},
                  **bpr_kw):
         super().__init__()
         if lr is None:
@@ -81,9 +61,10 @@ class _BertBPR(_LitValidated):
             setattr(self, name, getattr(self.hparams, name))
         self.training_prior_fcn = training_prior_fcn
 
-        self.item_tower = _Tower(
+        self.item_tower = NaiveItemTower(
             _create_bert(model_name, freeze_bert),
             torch.nn.LayerNorm(768, elementwise_affine=elementwise_affine),  # TODO: other transform layers
+            tokenizer=tokenizer, tokenizer_kw=tokenizer_kw,
         )
         self.all_inputs = all_inputs
 
@@ -104,7 +85,7 @@ class _BertBPR(_LitValidated):
             print(self._checkpoint.dirpath)
 
     def forward(self, batch):  # tokenized or ptr
-        output_step = getattr(self, "override_output_step", "final")
+        output_step = getattr(self, "override_output_step", "embedding")
         if isinstance(batch, collections.abc.Mapping):  # tokenized
             return self.item_tower(**batch, output_step=output_step)
         elif hasattr(self, 'all_cls'):  # ptr
@@ -156,6 +137,9 @@ class _BertBPR(_LitValidated):
         else:
             return torch.optim.Adagrad(self.parameters(),
                                        eps=1e-3, lr=self.lr, weight_decay=self.weight_decay)
+
+    def to_explainer(self, **kw):
+        return self.item_tower.to_explainer(**kw)
 
 
 class _DataModule(LightningDataModule):
@@ -220,7 +204,6 @@ class BertBPR:
             strategy = 'dp' if torch.cuda.device_count() > 1 else None
 
         self.item_titles = item_df['TITLE']
-        self._model_kw = {"freeze_bert": freeze_bert, "do_validation": do_validation, **kw}
         self.max_length = max_length
         self.batch_size = batch_size
         self.do_validation = do_validation
@@ -229,10 +212,12 @@ class BertBPR:
         self.strategy = strategy
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-        self.all_inputs = self.tokenizer(
-            self.item_titles.tolist(), padding='max_length', return_tensors='pt',
-            max_length=self.max_length, truncation=True
-        )
+        self.tokenizer_kw = dict(padding='max_length', return_tensors='pt',
+                                 max_length=self.max_length, truncation=True)
+        self.all_inputs = self.tokenizer(self.item_titles.tolist(), **self.tokenizer_kw)
+        self._model_kw = {"freeze_bert": freeze_bert, "do_validation": do_validation, **kw,
+                          "tokenizer": self.tokenizer, "tokenizer_kw": self.tokenizer_kw}
+
         self.model = _BertBPR(self.all_inputs, **self._model_kw)
         self.valid_batch_size = self.batch_size * self.model.n_negatives * 2 // self.model.valid_n_negatives
         self.predict_batch_size = 6 * self.batch_size
@@ -264,7 +249,7 @@ class BertBPR:
             model.override_output_step = 'cls'
             all_cls = trainer.predict(model, datamodule=dm)
             model.register_buffer("all_cls", torch.cat(all_cls), False)
-            del model.override_output_step  # restore to final
+            del model.override_output_step  # restore to embedding
 
         if _lr_find:
             lr_finder = trainer.tuner.lr_find(model, datamodule=dm,
@@ -300,5 +285,42 @@ class BertBPR:
         return auto_cast_lazy_score(user_final) @ item_final.T
 
     def to_explainer(self, **kw):
-        tower = self.model.item_tower.to(auto_device()).eval()
-        return I2IExplainer(tower, self.tokenizer, **kw)
+        return self.model.to_explainer(**kw)
+
+
+def bbpr_main(item_df, expl_response, gnd_response, max_epochs=50, alpha=0.05, beta=0.0,
+              user_df=None, convert_time_unit='s'):
+    """
+    item_df = get_item_df()[0]
+    expl_response = pd.read_json(
+        'vae-1000-queries-10-steps-response.json', lines=True, convert_dates=False
+    ).set_index('level_0')
+    gnd_response = pd.read_json(
+        'prime-pantry-i2i-online-baseline4-response.json', lines=True, convert_dates=False
+    ).set_index('level_0')
+    """
+    zero_shot = create_zero_shot(item_df, user_df=user_df)
+    train_requests = expl_response.set_index('request_time', append=True)
+    expl_events = parse_response(expl_response, convert_time_unit=convert_time_unit)
+    V = rime.dataset.Dataset(
+        zero_shot.user_df, item_df, pd.concat([zero_shot.event_df, expl_events]),
+        test_requests=train_requests[[]], test_update_history=False, horizon=0.1, sample_with_prior=1)
+    assert V.target_csr.nnz > 0
+
+    bbpr = BertBPR(
+        item_df, max_epochs=max_epochs, batch_size=10 * max(1, torch.cuda.device_count()),
+        sample_with_prior=True, sample_with_posterior=0,
+        replacement=False, n_negatives=5, valid_n_negatives=5,
+        training_prior_fcn=lambda x: (x + 1 / x.shape[1]).clip(0, None).log(),
+    )
+    bbpr.fit(V)
+
+    gnd_events = parse_response(gnd_response, convert_time_unit=convert_time_unit)
+    gnd = rime.dataset.Dataset(
+        zero_shot.user_df, item_df, pd.concat([zero_shot.event_df, gnd_events]),
+        test_requests=gnd_response.set_index('request_time', append=True)[[]],
+        sample_with_prior=1e5)
+    reranking_scores = bbpr.transform(gnd) + gnd.prior_score
+    metrics = rime.metrics.evaluate_item_rec(gnd.target_csr, reranking_scores, 1)
+
+    return metrics, reranking_scores, bbpr

--- a/src/ccrec/models/item_tower.py
+++ b/src/ccrec/models/item_tower.py
@@ -1,0 +1,86 @@
+import torch, pandas as pd, numpy as np, functools
+from datasets import Dataset, DatasetDict
+from rime.util import auto_device
+
+
+class ItemTowerBase(torch.nn.Module):
+    """ support texts -> inputs -> cls -> embedding / loss;
+    tokenizer is required for texts_to_inputs, to_map_fn and to_explainer for e2e inference """
+    def __init__(self, *module_list, tokenizer=None, tokenizer_kw={}):
+        super().__init__()
+        self.module_list = module_list
+        self.tokenizer = tokenizer
+        _default_tokenizer_kw = {'truncation': True, 'padding': 'max_length', 'max_length': 32, 'return_tensors': 'pt'}
+        self.tokenizer_kw = {**_default_tokenizer_kw, **tokenizer_kw}
+
+    @property
+    def device(self):
+        return self.module_list[0].device
+
+    def texts_to_inputs(self, texts):
+        return self.tokenizer(texts, **self.tokenizer_kw)
+
+    def forward(self, cls=None, texts=None, input_step='inputs', output_step='embedding', **inputs):
+        raise NotImplementedError(f"{self.__class__.__name__} does not support {input_step}->{output_step} forward")
+
+    def to_map_fn(self, input_step, output_step):
+        return functools.partial(self.forward, input_step=input_step, output_step=output_step)
+
+    def to_explainer(self, **kw):
+        from ccrec.util.shap_explainer import I2IExplainer
+        assert self.tokenizer is not None, "to_explainer requires tokenizer attribute"
+        self = self.to(auto_device()).eval()
+        return I2IExplainer(self, self.tokenizer, **kw)
+
+
+class NaiveItemTower(ItemTowerBase):
+    """ standard_layer_norm on top of cls token """
+    def __init__(self, cls_model, standard_layer_norm, **kw):
+        super().__init__(cls_model, standard_layer_norm, **kw)
+        self.cls_model = cls_model
+        self.standard_layer_norm = standard_layer_norm
+
+    def forward(self, cls=None, texts=None, input_step='inputs', output_step='embedding', **inputs):
+        if input_step == 'texts':
+            inputs = self.texts_to_inputs(texts=texts)
+            input_step = 'inputs'
+
+        if input_step == 'inputs':
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+            cls = self.cls_model(**inputs).last_hidden_state[:, 0]
+        else:  # cls
+            cls = cls.to(self.device)
+
+        if output_step == 'embedding':
+            return self.standard_layer_norm(cls)
+        elif output_step == 'cls':
+            return cls
+        raise NotImplementedError(f"{self.__class__.__name__} does not support {input_step}->{output_step} forward")
+
+
+class VAEItemTower(ItemTowerBase):
+    """ support reconstruction of (masked) inputs as well as cls/embedding outputs """
+    def __init__(self, ae_model, **kw):
+        super().__init__(ae_model, **kw)
+        self.ae_model = ae_model
+        self.cls_to_embedding = ae_model.cls_to_embedding
+
+    def forward(self, cls=None, texts=None, input_step='inputs', output_step='embedding', **inputs):
+        if input_step == 'texts':
+            inputs = self.texts_to_inputs(texts=texts)
+            input_step = 'inputs'
+
+        if input_step == 'inputs':
+            inputs = {k: v.to(self.ae_model.device) for k, v in inputs.items()}
+            if output_step == 'cls':
+                cls = self.ae_model(**inputs, return_cls=True)
+                return cls
+            if output_step == 'embedding':
+                return self.ae_model(**inputs, return_embedding=True)  # normalized embedding
+            elif output_step == 'dict':
+                return self.ae_model(**inputs, return_dict=True)  # ct loss and logits
+
+        elif input_step == 'cls':
+            if output_step == 'embedding':
+                return self.cls_to_embedding(cls)
+        raise NotImplementedError(f"{self.__class__.__name__} does not support {input_step}->{output_step} forward")

--- a/src/ccrec/util/__init__.py
+++ b/src/ccrec/util/__init__.py
@@ -1,5 +1,6 @@
 import collections, contextlib
 import numpy as np
+from rime.util import auto_device
 
 
 def merge_unique(list_of_lists, num_per_list, total, rng=np.random):
@@ -24,7 +25,7 @@ def merge_unique(list_of_lists, num_per_list, total, rng=np.random):
 
 
 @contextlib.contextmanager
-def _device_mode_context(module, device, training):
+def _device_mode_context(module, device=auto_device(), training=False):
     old_device = getattr(module, "device", 'cpu')
     old_training = module.training
     module.to(device)

--- a/src/ccrec/util/demo_data.py
+++ b/src/ccrec/util/demo_data.py
@@ -2,8 +2,6 @@ import pandas as pd, numpy as np, torch
 import pytest, dataclasses, functools
 import scipy.sparse as sps
 from rime.util import auto_cast_lazy_score, auto_device
-from ccrec.models.vae_lightning import vae_main
-from ccrec.models.bert_mt import bmt_main
 from attrdict import AttrDict
 from ccrec.env.i2i_env import Image, I2IImageEnv
 
@@ -62,12 +60,20 @@ class DemoData:
 
     @functools.lru_cache()
     def run_vae_main(self):
+        from ccrec.models.vae_lightning import vae_main
         return vae_main(self.item_df, self.gnd_response, max_epochs=self.max_epochs, user_df=self.user_df)
 
     @functools.lru_cache()
     def run_bmt_main(self):
+        from ccrec.models.bert_mt import bmt_main
         return bmt_main(self.item_df, self.expl_response, self.gnd_response,
                         max_epochs=self.max_epochs, user_df=self.user_df, convert_time_unit=self.convert_time_unit)
+
+    @functools.lru_cache()
+    def run_bbpr_main(self):
+        from ccrec.models.bbpr import bbpr_main
+        return bbpr_main(self.item_df, self.expl_response, self.gnd_response,
+                         max_epochs=self.max_epochs, user_df=self.user_df, convert_time_unit=self.convert_time_unit)
 
     @torch.no_grad()
     def create_embedding(self, explainer):

--- a/src/ccrec/util/shap_explainer.py
+++ b/src/ccrec/util/shap_explainer.py
@@ -81,11 +81,12 @@ class I2IExplainer:
         return dict(padding=True, return_tensors='pt', max_length=self.max_length, truncation=True)
 
     def _get_unitary_utility(self, texts):
-        if hasattr(self.item_tower, 'IS_AUTO_ENCODER') and self.item_tower.IS_AUTO_ENCODER:
+        from ccrec.models.item_tower import VAEItemTower
+        if isinstance(self.item_tower, VAEItemTower):
             _inputs = self.tokenizer(texts.tolist(), **self.tokenizer_kw)
             loss = self.item_tower(**_inputs, output_step='dict')[0].cpu().numpy()
             return -loss.ravel()
-        return np.ravel(1)
+        return np.ones(len(texts))
 
     def _get_pairwise_utility(self, x, cand_texts):
         _inputs = self.tokenizer(cand_texts.tolist(), **self.tokenizer_kw)

--- a/test/test_demo_data.py
+++ b/test/test_demo_data.py
@@ -7,6 +7,10 @@ def demo_data_obj():
     return DemoData()
 
 
+def test_bbpr_main(demo_data_obj):
+    return demo_data_obj.run_bbpr_main()
+
+
 def test_vae_main(demo_data_obj):
     return demo_data_obj.run_vae_main()
 


### PR DESCRIPTION
*Description of changes:*
* introduce item_tower for forwarding with different input/output stages. e.g., from raw text / tokenized inputs to cls / embedding / vae loss.
* delegate to_map_fn and to_explainer to item_tower. to_map_fn facilitate inputs with Dataset.map function and to_explainer facilitates shap connection. The item_tower module would maintain reference to tokenizer for to_map_fn and to_explainer functions.
* build all other classes on top of item_tower. Notice that we use torch.nn.Module for subcomponents and LightningModule for top-level models for additional training steps.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
